### PR TITLE
Add campics picture box to mainform

### DIFF
--- a/CVB/MainForm.Designer.vb
+++ b/CVB/MainForm.Designer.vb
@@ -25,6 +25,7 @@ Namespace CVB
         Private Sub InitializeComponent()
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(MainForm))
             MainToolStrip = New ToolStrip()
+            campics = New PictureBox()
             PausePlayButton = New ToolStripButton()
             SettingsToolStripButton = New ToolStripButton()
             TestAllButton = New ToolStripButton()
@@ -37,6 +38,7 @@ Namespace CVB
             ToolStripSeparator2 = New ToolStripSeparator()
             GroupComboBox = New ToolStripComboBox()
             AlgDescription = New ToolStripTextBox()
+            CType(campics, ComponentModel.ISupportInitialize).BeginInit()
             MainToolStrip.SuspendLayout()
             SuspendLayout()
             ' 
@@ -149,11 +151,24 @@ Namespace CVB
             AlgDescription.Text = "Description"
             AlgDescription.ToolTipText = "Description"
             ' 
+            ' campics
+            ' 
+            campics.Anchor = AnchorStyles.Top Or AnchorStyles.Left Or AnchorStyles.Right
+            campics.BackColor = SystemColors.ControlLight
+            campics.BorderStyle = BorderStyle.FixedSingle
+            campics.Location = New Point(12, 54)
+            campics.Name = "campics"
+            campics.Size = New Size(1864, 609)
+            campics.SizeMode = PictureBoxSizeMode.Zoom
+            campics.TabIndex = 1
+            campics.TabStop = False
+            ' 
             ' MainForm
             ' 
             AutoScaleDimensions = New SizeF(12F, 30F)
             AutoScaleMode = AutoScaleMode.Font
             ClientSize = New Size(1888, 675)
+            Controls.Add(campics)
             Controls.Add(MainToolStrip)
             Icon = CType(resources.GetObject("$this.Icon"), Icon)
             Margin = New Padding(4)
@@ -161,6 +176,7 @@ Namespace CVB
             Text = "CVB Application"
             MainToolStrip.ResumeLayout(False)
             MainToolStrip.PerformLayout()
+            CType(campics, ComponentModel.ISupportInitialize).EndInit()
             ResumeLayout(False)
             PerformLayout()
         End Sub
@@ -178,6 +194,7 @@ Namespace CVB
         Friend WithEvents GroupComboBox As ToolStripComboBox
         Friend WithEvents ToolStripButton1 As ToolStripButton
         Friend WithEvents AlgDescription As ToolStripTextBox
+        Friend WithEvents campics As PictureBox
 
     End Class
 End Namespace


### PR DESCRIPTION
Add a `PictureBox` named `campics` to the `MainForm` to provide a display area for camera imagery.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f4c5488-9238-4f77-8786-12a4358e38aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f4c5488-9238-4f77-8786-12a4358e38aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

